### PR TITLE
fix: set maximum width of the command help to 100 chars

### DIFF
--- a/argparse_to_md/formatter.py
+++ b/argparse_to_md/formatter.py
@@ -1,8 +1,13 @@
 import argparse
 import typing as t
 
+HELP_WIDTH = 100
+
 
 class MarkdownHelpFormatter(argparse.HelpFormatter):
+    def __init__(self, width=HELP_WIDTH, *args, **kwargs):
+        super().__init__(width=width, *args, **kwargs)
+
     def _format_usage(self, usage, actions, groups, prefix):
         prefix = "Usage:\n```\n"
         result = super()._format_usage(usage, actions, groups, prefix).rstrip("\n")

--- a/test/data/test1.md.expected
+++ b/test/data/test1.md.expected
@@ -3,13 +3,17 @@ Some text before
 <!--argparse_to_md:test1:get_parser-->
 Usage:
 ```
-testprog [-h] [--foo FOO] [--bar BAR]
+testprog [-h] [--foo FOO] [--bar BAR] [--baz BAZ] [--longer-argument LONGER_ARGUMENT]
+                    [--even-longer-argument EVEN_LONGER_ARGUMENT]
 ```
 Description of the program
 
 Optional arguments:
 - `--foo FOO`: foo help
 - `--bar BAR`: bar help
+- `--baz BAZ`: baz help
+- `--longer-argument LONGER_ARGUMENT`: longer-argument help
+- `--even-longer-argument EVEN_LONGER_ARGUMENT`: even-longer-argument help
 <!--argparse_to_md_end-->
 
 some text after

--- a/test/data/test1.py
+++ b/test/data/test1.py
@@ -7,4 +7,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog='testprog', description='Description of the program')
     parser.add_argument('--foo', help='foo help')
     parser.add_argument('--bar', help='bar help')
+    parser.add_argument('--baz', help='baz help')
+    parser.add_argument('--longer-argument', help='longer-argument help')
+    parser.add_argument('--even-longer-argument', help='even-longer-argument help')
+
     return parser


### PR DESCRIPTION
This MR sets the maximum width of the usage string in markdown help to 100 symbols.