### PR TITLE
fix:Added an empty line in front of the argument list

### DIFF
--- a/test/data/test1.md.expected
+++ b/test/data/test1.md.expected
@@ -9,6 +9,7 @@ testprog [-h] [--foo FOO] [--bar BAR] [--baz BAZ] [--longer-argument LONGER_ARGU
 Description of the program
 
 Optional arguments:
+
 - `--foo FOO`: foo help
 - `--bar BAR`: bar help
 - `--baz BAZ`: baz help

--- a/test/data/test2.md.expected
+++ b/test/data/test2.md.expected
@@ -7,5 +7,6 @@ testprog [-h] [--foo FOO]
 ```
 
 Optional arguments:
+
 - `--foo FOO`: foo help
 <!--argparse_to_md_end-->

--- a/test/data/test3.md.expected
+++ b/test/data/test3.md.expected
@@ -7,9 +7,11 @@ testprog [-h] [--opt5 OPT5] {foo,bar} ...
 ```
 
 Positional arguments:
+
 - {`foo`, `bar`}: action to run
 
 Optional arguments:
+
 - `--opt5 OPT5`: option 5
 
 ## Usage of `foo`:
@@ -20,6 +22,7 @@ testprog foo [-h] [--opt1 OPT1] [--opt2 OPT2]
 foo action
 
 Optional arguments of `foo`:
+
 - `--opt1 OPT1`: option 1
 - `--opt2 OPT2`: option 2
 
@@ -31,6 +34,7 @@ testprog bar [-h] [--opt3 OPT3] [--opt4 OPT4]
 bar action
 
 Optional arguments of `bar`:
+
 - `--opt3 OPT3`: option 3
 - `--opt4 OPT4`: option 4
 <!--argparse_to_md_end-->


### PR DESCRIPTION
### The main problem occurs after rendering a file from markdown format to pdf. 

Some engines, for example Markdown.pl ,as well as markdown, which is used by a tool such as pandoc by default, do not behave correctly. They can't identify the beginning of the lists in Markdown.
#### test2.md (from test)
````markdown
Usage:
```
testprog [-h] [--foo FOO]
```

Optional arguments:
- `--foo FOO`: foo no help
````

Аfter render to pdf with pandoc: 
```bash
pandoc -f markdown test2.md -o test_default.pdf
```
We get the followind file [test2_default.pdf](https://github.com/user-attachments/files/24697860/test2_default.pdf)

If we change engine for rendering markdown, 
```bash
pandoc -f commonmark test2.md -o test2_commonmark.pdf
```
Result will be like [test2_commonmark.pdf](https://github.com/user-attachments/files/24697875/test2_commonmark.pdf)

---
Yes, it may not be the job of this software to take care of how the file will be converted in the future, but it will be useful for other tools that participate in the CI/CD process.
