### PR TITLE
feat: add pad_lists option for empty line before markdown lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Output can be customized by passing additional options in the comment:
 The following options are supported:
 
 - `subheading_level` (default `0`): if set to a non-zero value, the `Usage` line and all the `Usage` lines related to subparsers are prefixed with a markdown heading of respective level. For example, when specifying `subheading_level=2`, the final output will contain `## Usage:` instead of `Usage:`.
+- `pad_lists` (default `0`): if set to `1`, an empty line is added before each markdown list. Some markdown renderers require this blank line for proper list rendering.
 
 ### Related projects
 

--- a/argparse_to_md/markdown_processor.py
+++ b/argparse_to_md/markdown_processor.py
@@ -68,7 +68,12 @@ def args_to_options(args: str) -> MarkdownHelpFormatterOptions:
         subheading_level = int(args_dict["subheading_level"])
         del args_dict["subheading_level"]
 
+    pad_lists = False
+    if "pad_lists" in args_dict:
+        pad_lists = bool(int(args_dict["pad_lists"]))
+        del args_dict["pad_lists"]
+
     if args_dict:
         raise ValueError(f"Unknown arguments: {args_dict}")
 
-    return MarkdownHelpFormatterOptions(subheading_level=subheading_level)
+    return MarkdownHelpFormatterOptions(subheading_level=subheading_level, pad_lists=pad_lists)

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -355,3 +355,50 @@ def test_gen_argparse_help_custom_usage():
 
     result = out.getvalue()
     assert "myprog [options] FILE\n" in result
+
+
+def test_gen_argparse_help_pad_lists():
+    parser = argparse.ArgumentParser(prog="myprog", description="My program")
+    parser.add_argument("--foo", help="foo help")
+
+    out = io.StringIO()
+    gen_argparse_help(parser, out, MarkdownHelpFormatterOptions(pad_lists=True))
+
+    result = out.getvalue()
+    assert "Optional arguments:\n\n- `--foo FOO`: foo help\n" in result
+
+
+def test_gen_argparse_help_no_pad_lists():
+    parser = argparse.ArgumentParser(prog="myprog", description="My program")
+    parser.add_argument("--foo", help="foo help")
+
+    out = io.StringIO()
+    gen_argparse_help(parser, out, MarkdownHelpFormatterOptions(pad_lists=False))
+
+    result = out.getvalue()
+    assert "Optional arguments:\n- `--foo FOO`: foo help\n" in result
+
+
+def test_gen_argparse_help_pad_lists_with_subparsers():
+    parser = argparse.ArgumentParser(prog="myprog")
+    subparsers = parser.add_subparsers(dest="cmd", help="command")
+    sub = subparsers.add_parser("run", description="run cmd")
+    sub.add_argument("--fast", action="store_true", help="go fast")
+
+    out = io.StringIO()
+    gen_argparse_help(parser, out, MarkdownHelpFormatterOptions(pad_lists=True))
+
+    result = out.getvalue()
+    assert "Optional arguments of `run`:\n\n- `--fast`: go fast\n" in result
+
+
+def test_gen_argparse_help_pad_lists_with_subheading():
+    parser = argparse.ArgumentParser(prog="myprog")
+    parser.add_argument("--foo", help="foo help")
+
+    out = io.StringIO()
+    gen_argparse_help(parser, out, MarkdownHelpFormatterOptions(subheading_level=2, pad_lists=True))
+
+    result = out.getvalue()
+    assert result.startswith("## Usage:\n")
+    assert "Optional arguments:\n\n- `--foo FOO`: foo help\n" in result

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -80,6 +80,11 @@ def test_subparsers():
 def test_arguments_to_options():
     assert args_to_options("") == MarkdownHelpFormatterOptions()
     assert args_to_options("subheading_level=2") == MarkdownHelpFormatterOptions(subheading_level=2)
+    assert args_to_options("pad_lists=1") == MarkdownHelpFormatterOptions(pad_lists=True)
+    assert args_to_options("pad_lists=0") == MarkdownHelpFormatterOptions(pad_lists=False)
+    assert args_to_options("subheading_level=2:pad_lists=1") == MarkdownHelpFormatterOptions(
+        subheading_level=2, pad_lists=True
+    )
     with pytest.raises(ValueError):
         args_to_options("subheading_level=2:foo=bar")
     with pytest.raises(ValueError):


### PR DESCRIPTION
Some markdown renderers require a blank line before a list for proper rendering. The pad_lists option (0/1) controls whether an empty line is added before argument lists in the generated markdown output.

Serves the same purpose as https://github.com/igrr/argparse_to_md/pull/4, but is based on the updated formatter implementation.