### PR TITLE
fix: accumulate multiple --input flags and add process cwd to loader path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ You can also use argparse_to_md from the command line:
 <!-- argparse_to_md:argparse_to_md.__main__:get_parser -->
 Usage:
 ```
-argparse_to_md [-h] [-i INPUT [INPUT ...]] [--extra-sys-path EXTRA_SYS_PATH [EXTRA_SYS_PATH ...]]
+argparse_to_md [-h] [-i INPUT [-i INPUT ...]] [--extra-sys-path EXTRA_SYS_PATH [EXTRA_SYS_PATH ...]]
                [--check] [--version]
 ```
 
 Optional arguments:
-- `-i INPUT [INPUT ...]`, `--input INPUT [INPUT ...]`: Markdown file to update (can be specified multiple times).
+- `-i INPUT [-i INPUT ...]`, `--input INPUT [--input INPUT ...]`: Markdown file to update (can be specified multiple times).
 - `--extra-sys-path EXTRA_SYS_PATH [EXTRA_SYS_PATH ...]`: Extra paths to add to PYTHONPATH before loading the module
 - `--check`: Check if the files need to be updated, but don't modify them. Non-zero exit code is returned if any file needs to be updated.
 - `--version`: show program's version number and exit

--- a/argparse_to_md/formatter.py
+++ b/argparse_to_md/formatter.py
@@ -57,6 +57,11 @@ def _format_args(action: argparse.Action, metavar: t.Union[str, tuple]) -> str:
         return " ".join([metavar] * int(action.nargs))
 
 
+def _is_extend_action(action: argparse.Action) -> bool:
+    extend_cls = getattr(argparse, "_ExtendAction", None)
+    return extend_cls is not None and isinstance(action, extend_cls)
+
+
 def _format_usage_part(action: argparse.Action) -> t.Optional[str]:
     if action.help is argparse.SUPPRESS:
         return None
@@ -68,6 +73,9 @@ def _format_usage_part(action: argparse.Action) -> t.Optional[str]:
     else:
         if action.nargs == 0:
             part = action.option_strings[0]
+        elif _is_extend_action(action) and action.nargs == argparse.ONE_OR_MORE:
+            opt = action.option_strings[0]
+            part = "%s %s [%s %s ...]" % (opt, metavar, opt, metavar)
         else:
             args_str = _format_args(action, metavar)
             part = "%s %s" % (action.option_strings[0], args_str)
@@ -155,6 +163,8 @@ def _format_action_md(action: argparse.Action) -> str:
     else:
         if action.nargs == 0:
             parts = ["`%s`" % os for os in action.option_strings]
+        elif _is_extend_action(action) and action.nargs == argparse.ONE_OR_MORE:
+            parts = ["`%s %s [%s %s ...]`" % (os, metavar, os, metavar) for os in action.option_strings]
         else:
             args_str = _format_args(action, metavar)
             parts = ["`%s %s`" % (os, args_str) for os in action.option_strings]

--- a/argparse_to_md/loader.py
+++ b/argparse_to_md/loader.py
@@ -31,7 +31,7 @@ class FunctionLoader:
         :param function_name: The name of the function to load from the module.
         :param cwd: Optional: the current working directory, to add to the sys.path.
         """
-        extra_sys_path = self.extra_sys_path
+        extra_sys_path = list(self.extra_sys_path)
         if cwd is not None:
             extra_sys_path = [cwd] + extra_sys_path
         with self._sys_path_extend(extra_sys_path):

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -168,6 +168,12 @@ def test_format_usage_part_nargs_plus():
     assert _format_usage_part(action) == "[-i INPUT [INPUT ...]]"
 
 
+def test_format_usage_part_extend_nargs_plus():
+    parser = argparse.ArgumentParser()
+    action = parser.add_argument("-i", "--input", nargs="+", action="extend", default=[])
+    assert _format_usage_part(action) == "[-i INPUT [-i INPUT ...]]"
+
+
 # --- _build_usage_parts ---
 
 
@@ -277,6 +283,14 @@ def test_format_action_md_nargs_plus_multiple_opts():
     parser = argparse.ArgumentParser()
     action = parser.add_argument("-i", "--input", nargs="+", help="input files")
     assert _format_action_md(action) == "- `-i INPUT [INPUT ...]`, `--input INPUT [INPUT ...]`: input files\n"
+
+
+def test_format_action_md_extend_nargs_plus():
+    parser = argparse.ArgumentParser()
+    action = parser.add_argument("-i", "--input", nargs="+", action="extend", default=[], help="input files")
+    assert (
+        _format_action_md(action) == "- `-i INPUT [-i INPUT ...]`, `--input INPUT [--input INPUT ...]`: input files\n"
+    )
 
 
 def test_format_action_md_positional():


### PR DESCRIPTION
- Use action="extend" for --input so that repeating --input accumulates values instead of silently overriding.
- Add the process working directory as a fallback in the loader's sys.path, so modules at the repo root can be found when input files are in subdirectories
- Add correct formatting for the case of `nargs='+', action='extend'`

Closes #9
Closes #10